### PR TITLE
Add suggested changes and unit tests to WaitGroup workflow wrapper

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1360,7 +1360,6 @@ func (h *queryHandler) execute(input []byte) (result []byte, err error) {
 //
 // param delta int32 -> the value to increment the WaitGroup counter by
 func (wg *waitGroupImpl) Add(delta int32) {
-	state := wg.waiting
 	wg.n = wg.n + delta
 	if wg.n < 0 {
 		panic("negative WaitGroup counter")
@@ -1370,9 +1369,6 @@ func (wg *waitGroupImpl) Add(delta int32) {
 	}
 	if (wg.n > 0) || (!wg.waiting) {
 		return
-	}
-	if wg.waiting != state {
-		panic("WaitGroup misuse: Add called concurrently with Wait")
 	}
 	if wg.n == 0 {
 		wg.settable.set(false, nil)
@@ -1401,8 +1397,5 @@ func (wg *waitGroupImpl) Wait(ctx Context) {
 	if err := wg.future.Get(ctx, &wg.waiting); err != nil {
 		panic(err)
 	}
-	
-	f, s := NewFuture(ctx)
-	wg.future = f
-	wg.settalbe = s
+	wg.future, wg.settable := NewFuture(ctx)
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -71,10 +71,10 @@ type (
 
 	// Implements WaitGroup interface
 	waitGroupImpl struct {
-		n        int32       // the number of coroutines to wait on
-		waiting  bool        // indicates whether WaitGroup.Wait() has been called yet for the WaitGroup
-		future   Future	     // future to signal that all awaited members of the WaitGroup have completed
-		settable Settable    // used to unblock the future when all coroutines have completed
+		n        int32    // the number of coroutines to wait on
+		waiting  bool     // indicates whether WaitGroup.Wait() has been called yet for the WaitGroup
+		future   Future   // future to signal that all awaited members of the WaitGroup have completed
+		settable Settable // used to unblock the future when all coroutines have completed
 	}
 
 	// Dispatcher is a container of a set of coroutines.
@@ -1371,7 +1371,7 @@ func (wg *waitGroupImpl) Add(delta int32) {
 		return
 	}
 	if wg.n == 0 {
-		wg.settable.set(false, nil)
+		wg.settable.Set(false, nil)
 	}
 }
 
@@ -1397,5 +1397,5 @@ func (wg *waitGroupImpl) Wait(ctx Context) {
 	if err := wg.future.Get(ctx, &wg.waiting); err != nil {
 		panic(err)
 	}
-	wg.future, wg.settable := NewFuture(ctx)
+	wg.future, wg.settable = NewFuture(ctx)
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -307,7 +307,8 @@ func NewNamedSelector(ctx Context, name string) Selector {
 
 // NewWaitGroup creates a new WaitGroup instance.
 func NewWaitGroup(ctx Context) WaitGroup {
-	return &waitGroupImpl{future: &futureImpl{channel: NewChannel(ctx).(*channelImpl)}}
+	f, s := NewFuture(ctx)
+	return &waitGroupImpl{future: f, settable: s}
 }
 
 // Go creates a new coroutine. It has similar semantic to goroutine in a context of the workflow.


### PR DESCRIPTION
WaitGroup now holds Future and Settable interfaces instead of a futureImpl.  Settable is used to unblock the WaitGroup.Wait().

Added unit tests in internal_workflow_test.go to test all special cases for WaitGroup:

> If the counter becomes zero, all goroutines blocked on Wait are released. If the counter goes negative, Add panics.  Note that calls with a positive delta that occur when the counter is zero must happen before a Wait. Calls with a negative delta, or calls with a positive delta that start when the counter is greater than zero, may happen at any time. Typically this means the calls to Add should execute before the statement creating the goroutine or other event to be waited for. If a WaitGroup is reused to wait for several independent sets of events, new Add calls must happen after all previous Wait calls have returned. See the WaitGroup example.  

Unit tests cover all lines of WaitGroup code (aside from the panic() during Future.Get() error handling).
