### PR TITLE
remove concurrent WaitGroup.Add(+)/WaitGroup.Wait() impossible case heck from WaitGroup.Add()

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1370,10 +1370,6 @@ func (h *queryHandler) execute(input []byte) (result []byte, err error) {
 //
 // param delta int32 -> the value to increment the WaitGroup counter by
 func (wg *waitGroupImpl) Add(delta int32) {
-	if (wg.waiting && delta > 0) && (wg.n == 0) {
-		panic("WaitGroup misuse: Add called concurrently with Wait")
-	}
-
 	wg.n = wg.n + delta
 	if wg.n < 0 {
 		panic("negative WaitGroup counter")

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1113,42 +1113,6 @@ func waitGroupNegativeCounterPanicsWorkflowTest(ctx Context) (int, error) {
 	return result, nil
 }
 
-func waitGroupWaitConcurrentAddPanicsWorkflowTest(ctx Context) (int, error) {
-	ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
-		ExecutionStartToCloseTimeout: time.Second * 30,
-	})
-
-	var err error
-	var result int
-
-	waitGroup := NewWaitGroup(ctx).(*waitGroupImpl)
-	waitGroup.waiting = true
-	waitGroup.Add(1)
-
-	Go(ctx, func(ctx Context) {
-		err = ExecuteChildWorkflow(ctx, sleepWorkflow, time.Second*5).Get(ctx, &result)
-		waitGroup.Done()
-	})
-
-	waitGroup.Wait(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	return result, nil
-}
-
-func (s *WorkflowUnitTest) Test_waitGroupWaitConcurrentAddPanicsWorkflowTest() {
-	env := s.NewTestWorkflowEnvironment()
-	RegisterWorkflow(waitGroupWaitConcurrentAddPanicsWorkflowTest)
-	env.ExecuteWorkflow(waitGroupWaitConcurrentAddPanicsWorkflowTest)
-	s.True(env.IsWorkflowCompleted())
-
-	resultErr := env.GetWorkflowError().(*PanicError)
-	s.EqualValues("WaitGroup misuse: Add called concurrently with Wait", resultErr.Error())
-	s.Contains(resultErr.StackTrace(), "cadence/internal.waitGroupWaitConcurrentAddPanicsWorkflowTest")
-}
-
 func (s *WorkflowUnitTest) Test_waitGroupNegativeCounterPanicsWorkflowTest() {
 	env := s.NewTestWorkflowEnvironment()
 	RegisterWorkflow(waitGroupNegativeCounterPanicsWorkflowTest)


### PR DESCRIPTION
I removed the concurrent Add/Wait when WaitGroup counter == 0.  This code is not possible to reach in a workflow context.

Removed the associated unit tests that tested this behavior.   Ran local coverage tests and no coverage has been lost.