### PR TITLE
Change counter in WaitGroup to int from int32

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -71,7 +71,7 @@ type (
 
 	// Implements WaitGroup interface
 	waitGroupImpl struct {
-		n        int32    // the number of coroutines to wait on
+		n        int      // the number of coroutines to wait on
 		waiting  bool     // indicates whether WaitGroup.Wait() has been called yet for the WaitGroup
 		future   Future   // future to signal that all awaited members of the WaitGroup have completed
 		settable Settable // used to unblock the future when all coroutines have completed
@@ -1368,8 +1368,8 @@ func (h *queryHandler) execute(input []byte) (result []byte, err error) {
 // If a WaitGroup is reused to wait for several independent sets of events,
 // new Add calls must happen after all previous Wait calls have returned.
 //
-// param delta int32 -> the value to increment the WaitGroup counter by
-func (wg *waitGroupImpl) Add(delta int32) {
+// param delta int -> the value to increment the WaitGroup counter by
+func (wg *waitGroupImpl) Add(delta int) {
 	wg.n = wg.n + delta
 	if wg.n < 0 {
 		panic("negative WaitGroup counter")

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -990,7 +990,7 @@ func waitGroupWorkflowTest(ctx Context, n int) (int, error) {
 	return sum, nil
 }
 
-func waitGroupWaitForMWorkflowTest(ctx Context, n int, m int32) (int, error) {
+func waitGroupWaitForMWorkflowTest(ctx Context, n int, m int) (int, error) {
 	ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
 		ExecutionStartToCloseTimeout: time.Second * 30,
 	})
@@ -1031,7 +1031,7 @@ func waitGroupMultipleWaitsWorkflowTest(ctx Context) (int, error) {
 	var err error
 	results := make([]int, 0, n)
 	waitGroup := NewWaitGroup(ctx)
-	waitGroup.Add(int32(4))
+	waitGroup.Add(4)
 	for i := 0; i < n; i++ {
 		t := time.Second * time.Duration(i+1)
 		Go(ctx, func(ctx Context) {
@@ -1047,7 +1047,7 @@ func waitGroupMultipleWaitsWorkflowTest(ctx Context) (int, error) {
 		return 0, err
 	}
 
-	waitGroup.Add(int32(6))
+	waitGroup.Add(6)
 	waitGroup.Wait(ctx)
 	if err != nil {
 		return 0, err
@@ -1152,12 +1152,12 @@ func (s *WorkflowUnitTest) Test_WaitGroupWaitForMWorkflowTest() {
 	RegisterWorkflow(waitGroupWaitForMWorkflowTest)
 
 	n := 10
-	m := int32(5)
+	m := 5
 	env.ExecuteWorkflow(waitGroupWaitForMWorkflowTest, n, m)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 
-	var total int32
+	var total int
 	env.GetWorkflowResult(&total)
 	s.Equal(m, total)
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -85,7 +85,7 @@ type (
 	// workflow code.  Use workflow.NewWaitGroup(ctx) method to create
 	// a new WaitGroup instance
 	WaitGroup interface {
-		Add(delta int32)
+		Add(delta int)
 		Done()
 		Wait(ctx Context)
 	}


### PR DESCRIPTION
1. Changed the `n` property in the `waitGroupImpl` to an `int` from an `int32`.  
2. Changed the `delta int32` WaitGroup.Add() parameter from an `int32` to an `int` to align more with the native golang `sync.WaitGroup.Add()` method. 
3. Edited the WaitGroup unit tests to reflect this change.